### PR TITLE
browser fix - pre-load files with brfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "elliptic": "^6.3.2",
     "multihashing": "^0.2.1",
     "node-forge": "^0.6.39",
-    "protocol-buffers": "^3.1.6"
+    "protocol-buffers": "^3.1.6",
+    "brfs": "^1.4.3"
   },
   "devDependencies": {
     "aegir": "^8.0.0",
@@ -41,6 +42,11 @@
   ],
   "engines": {
     "node": "^4.0.0"
+  },
+  "browserify": {
+    "transform": [
+      "brfs"
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We are loading a file via `fs` here https://github.com/libp2p/js-libp2p-crypto/blob/master/src/index.js#L6

This breaks support for module consumers using [browserify](https://github.com/substack/node-browserify). The [brfs](https://github.com/substack/brfs) module fixes this. The flag in the `package.json` indicates that this module requires pre-processing via the local brfs dependency to be imported correctly.