### PR TITLE
Fix for browserify 

### DIFF
--- a/src/crypto/util.js
+++ b/src/crypto/util.js
@@ -5,7 +5,7 @@ const BN = require('asn1.js').bignum
 // Convert a BN.js instance to a base64 encoded string without padding
 // Adapted from https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-41#appendix-C
 exports.toBase64 = function toBase64 (bn) {
-  let s = bn.toBuffer('be').toString('base64')
+  let s = bn.toArrayLike(Buffer, 'be').toString('base64')
 
   return s
     .replace(/(=*)$/, '') // Remove any trailing '='s

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -1,0 +1,21 @@
+/* eslint max-nested-callbacks: ["error", 8] */
+/* eslint-env mocha */
+'use strict'
+
+const expect = require('chai').expect
+const util = require('../src/crypto/util')
+const BN = require('bn.js')
+
+describe('Util', () => {
+  let bn
+
+  before((done) => {
+    bn = new BN('dead', 16)
+    done()
+  })
+
+  it('toBase64', (done) => {
+    expect(util.toBase64(bn)).to.be.eql('3q0')
+    done()
+  })
+})


### PR DESCRIPTION
`util.toBase64` would throw an error as `bn.toBuffer` doesn't work with browserify. `bn.toArrayLike` is used instead. 

`bn.toBuffer` is a simple wrapper for `bn.toArrayLike` anyway so there are no downsides here between node/browser.

https://github.com/indutny/bn.js/blob/master/lib/bn.js#L516

Fixes: #41 
