### PR TITLE
fix: use browserify-optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "aegir": "^10.0.0",
     "benchmark": "^2.1.3",
+    "browserify-optional": "^1.0.0",
     "chai": "^3.5.0",
     "pre-commit": "^1.2.2"
   },
@@ -62,6 +63,11 @@
   "engines": {
     "node": ">=4.0.0",
     "npm": ">=3.0.0"
+  },
+  "browserify": {
+    "transform": [
+      "browserify-optional"
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This works around the issue that browserify throws on missing modules.

Ref #70 