### PR TITLE
Allow base64 to be left 0 padded, and do so in ecdh key unmarshalling

### DIFF
--- a/src/crypto/ecdh-browser.js
+++ b/src/crypto/ecdh-browser.js
@@ -117,8 +117,8 @@ function unmarshalPublicKey (curve, key) {
   return {
     kty: 'EC',
     crv: curve,
-    x: toBase64(x),
-    y: toBase64(y),
+    x: toBase64(x, byteLen),
+    y: toBase64(y, byteLen),
     ext: true
   }
 }

--- a/src/crypto/util.js
+++ b/src/crypto/util.js
@@ -5,8 +5,9 @@ const Buffer = require('safe-buffer').Buffer
 
 // Convert a BN.js instance to a base64 encoded string without padding
 // Adapted from https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-41#appendix-C
-exports.toBase64 = function toBase64 (bn) {
-  let s = bn.toArrayLike(Buffer, 'be').toString('base64')
+exports.toBase64 = function toBase64 (bn, len) {
+  // if len is defined then the bytes are leading-0 padded to the length
+  let s = bn.toArrayLike(Buffer, 'be', len).toString('base64')
 
   return s
     .replace(/(=*)$/, '') // Remove any trailing '='s

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -22,4 +22,10 @@ describe('Util', () => {
     expect(util.toBase64(bn)).to.be.eql('3q0')
     done()
   })
+
+  it('toBase64 zero padding', (done) => {
+    let bnpad = new BN('ff', 16)
+    expect(util.toBase64(bnpad, 2)).to.be.eql('AP8')
+    done()
+  })
 })


### PR DESCRIPTION
JWK format, at least for elliptical key import, requires x and y values (base64 encoded) to be an expected byte length, so the buffer that comes out of the bn.js toArrayLike function must be left padded. Currently if the first byte of 32 is 0, a 31 byte buffer is returned from toArrayLike, and the resulting base64 reflects this. If 32 is passed to the toBase64() function as 'len', then the first byte is now set as 0.

This fixes #97. There may be similar issues elsewhere, in which case they can also pass a length value to toBase64(). In the meantime, this fixes unmarshalPublicKey() in ecdh-browser.js