### PR TITLE
feat: use aes-js for faaaster crypto in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": {
     "./src/hmac/index.js": "./src/hmac/index-browser.js",
     "./src/keys/ecdh.js": "./src/keys/ecdh-browser.js",
-    "./src/aes/ciphers.js": "./src/aes/ciphers-browser.js",
+    "./src/aes/index.js": "./src/aes/index-browser.js",
     "./src/keys/rsa.js": "./src/keys/rsa-browser.js"
   },
   "scripts": {
@@ -30,6 +30,7 @@
   "author": "Friedel Ziegelmayer <dignifiedquire@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "aes-js": "^3.1.0",
     "asn1.js": "^4.9.1",
     "async": "^2.5.0",
     "browserify-aes": "^1.0.6",

--- a/src/aes/ciphers-browser.js
+++ b/src/aes/ciphers-browser.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const crypto = require('browserify-aes')
-
-module.exports = {
-  createCipheriv: crypto.createCipheriv,
-  createDecipheriv: crypto.createDecipheriv
-}

--- a/src/aes/ciphers.js
+++ b/src/aes/ciphers.js
@@ -1,8 +1,0 @@
-'use strict'
-
-const crypto = require('crypto')
-
-module.exports = {
-  createCipheriv: crypto.createCipheriv,
-  createDecipheriv: crypto.createDecipheriv
-}

--- a/src/aes/index-browser.js
+++ b/src/aes/index-browser.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const aes = require('aes-js')
+const Ctr = aes.ModeOfOperation.ctr
+
+exports.create = function (key, iv, callback) {
+  const cipher = new Ctr(key, new aes.Counter(iv))
+  const decipher = new Ctr(key, new aes.Counter(iv))
+
+  const res = {
+    encrypt (data, cb) {
+      cb(null, Buffer.from(cipher.encrypt(data)))
+    },
+
+    decrypt (data, cb) {
+      cb(null, Buffer.from(decipher.decrypt(data)))
+    }
+  }
+
+  callback(null, res)
+}

--- a/src/aes/index.js
+++ b/src/aes/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ciphers = require('./ciphers')
+const crypto = require('crypto')
 
 const CIPHER_MODES = {
   16: 'aes-128-ctr',
@@ -13,8 +13,8 @@ exports.create = function (key, iv, callback) {
     return callback(new Error('Invalid key length'))
   }
 
-  const cipher = ciphers.createCipheriv(mode, key, iv)
-  const decipher = ciphers.createDecipheriv(mode, key, iv)
+  const cipher = crypto.createCipheriv(mode, key, iv)
+  const decipher = crypto.createDecipheriv(mode, key, iv)
 
   const res = {
     encrypt (data, cb) {


### PR DESCRIPTION
This doesn't have the stream overhead, and in general performs much better than browserify-aes