### PR TITLE
Remove unnecessary setImmediate

### DIFF
--- a/benchmarks/ephemeral-keys.js
+++ b/benchmarks/ephemeral-keys.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict'
 
 const Benchmark = require('benchmark')

--- a/benchmarks/key-stretcher.js
+++ b/benchmarks/key-stretcher.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict'
 
 const Benchmark = require('benchmark')

--- a/benchmarks/rsa.js
+++ b/benchmarks/rsa.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict'
 
 const Benchmark = require('benchmark')

--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
     "protons": "^1.0.1",
     "rsa-pem-to-jwk": "^1.1.3",
     "tweetnacl": "^1.0.0",
-    "ursa-optional": "~0.9.8",
+    "ursa-optional": "~0.9.9",
     "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
   },
   "devDependencies": {
-    "aegir": "^15.2.0",
+    "aegir": "^17.0.1",
     "benchmark": "^2.1.4",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "chai-string": "^1.5.0",
     "dirty-chai": "^2.0.1"
   },

--- a/src/hmac/index.js
+++ b/src/hmac/index.js
@@ -10,9 +10,7 @@ exports.create = function (hash, secret, callback) {
 
       hmac.update(data)
 
-      setImmediate(() => {
-        cb(null, hmac.digest())
-      })
+      cb(null, hmac.digest())
     },
     length: lengths[hash]
   }


### PR DESCRIPTION
This PR:

* Updates deps
* Fixes lint warnings for the benchmark console logs
* Removes setImmediate from `hmac.create` since it's unncessary

The setImmediate isn't needed and this removal makes it the same as `aes.create`. This is aggravating an issue with spdy not properly closing streams, which is causing https://github.com/libp2p/js-libp2p/pull/269 to fail. While this doesn't fix the underlying issue with spdy (I'm working on that separately), it does fix the failing tests at https://github.com/libp2p/js-libp2p/pull/269.