### PR TITLE
chore: updates libp2p-crypto-secp256k1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bs58": "^4.0.1",
     "iso-random-stream": "^1.1.0",
     "keypair": "^1.0.1",
-    "libp2p-crypto-secp256k1": "~0.2.3",
+    "libp2p-crypto-secp256k1": "~0.3.0",
     "multihashing-async": "~0.5.1",
     "node-forge": "~0.7.6",
     "pem-jwk": "^2.0.0",


### PR DESCRIPTION
Hey @dignifiedquire It seems like this repo also needs to update the dependency as https://github.com/libp2p/js-libp2p-keychain depends on this one