### PR TITLE
chore: use travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: node_js
+
+cache: npm
+
+stages:
+  - check
+  - test
+  - cov
+
+node_js:
+  - '10'
+
+os:
+  - linux
+  - osx
+  - windows
+
+script: npx nyc -s npm run test:node -- --bail
+after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+
+jobs:
+  include:
+    - stage: check
+      script:
+        - npx aegir commitlint --travis
+        - npx aegir dep-check
+        - npm run lint
+
+    - stage: test
+      name: chrome
+      addons:
+        chrome: stable
+      script:
+        - npx aegir test -t browser
+
+    - stage: test
+      name: firefox
+      addons:
+        firefox: latest
+      script:
+        - npx aegir test -t browser -- --browsers FirefoxHeadless
+
+notifications:
+  email: false

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,2 +1,0 @@
-// Warning: This file is automatically synced from https://github.com/ipfs/ci-sync so if you want to change it, please change it there and ask someone to sync all repositories.
-javascript()

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "asmcrypto.js": "^2.3.2",
     "asn1.js": "^5.0.1",
     "async": "^2.6.1",
+    "bn.js": "^4.11.8",
     "browserify-aes": "^1.2.0",
     "bs58": "^4.0.1",
     "iso-random-stream": "^1.1.0",


### PR DESCRIPTION
This PR changes Jenkins to travis for CI. In addition, 2 dependencies were missing in the `package.json` and the `dep-check` was not passing.