### PR TITLE
feat: bring your own web crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,40 @@ This repo contains the JavaScript implementation of the crypto primitives needed
 npm install --save libp2p-crypto
 ```
 
+## Usage
+
+```js
+const crypto = require('libp2p-crypto')
+
+// Now available to you:
+//
+// crypto.aes
+// crypto.hmac
+// crypto.keys
+// etc.
+//
+// See full API details below...
+```
+
+### Web Crypto API
+
+The `libp2p-crypto` library depends on the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) in the browser. Web Crypto is available in all modern browsers, however browsers restrict its usage to [Secure Contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).
+
+**This means you will not be able to use `libp2p-crypto` in the browser when the page is served over HTTP.**
+
+You can either move your page to be served over HTTPS or bring your own Web Crypto API implementation. If `libp2p-crypto` does not find the official Web Crypto API at `window.crypto` (or `self.crypto`) it will use `window.__crypto`.
+
+```js
+if (!window.isSecureContext) {
+  window.__crypto = // ... your Web Crypto API compatible implementation
+}
+```
+
 ## API
 
 ### `crypto.aes`
 
-Expoes an interface to AES encryption (formerly Rijndael), as defined in U.S. Federal Information Processing Standards Publication 197.
+Exposes an interface to AES encryption (formerly Rijndael), as defined in U.S. Federal Information Processing Standards Publication 197.
 
 This uses `CTR` mode.
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,3 +1,5 @@
+'use strict'
+
 exports.ERR_MISSING_WEB_CRYPTO = () => Object.assign(
   new Error(
     'Missing Web Crypto API. ' +

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,10 @@
+exports.ERR_MISSING_WEB_CRYPTO = () => Object.assign(
+  new Error(
+    'Missing Web Crypto API. ' +
+    'The most likely cause of this error is that this page is being accessed ' +
+    'from an insecure context (i.e. not HTTPS). For more information and ' +
+    'possible resolutions see ' +
+    'https://github.com/libp2p/js-libp2p-crypto/blob/master/README.md#web-crypto-api'
+  ),
+  { code: 'ERR_MISSING_WEB_CRYPTO' }
+)

--- a/src/webcrypto.js
+++ b/src/webcrypto.js
@@ -1,5 +1,11 @@
-/* global self */
+/* eslint-env browser */
 
 'use strict'
 
-module.exports = self.crypto || self.msCrypto
+// Check native crypto exists and is enabled (In insecure context `self.crypto`
+// exists but `self.crypto.subtle` does not). Fallback to custom Web Crypto API
+// compatible implementation at `self.__crypto` if no native.
+exports.get = (win = self) => {
+  const nativeCrypto = win.crypto || win.msCrypto
+  return nativeCrypto && nativeCrypto.subtle ? nativeCrypto : win.__crypto
+}

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,0 +1,86 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+const crypto = require('../')
+const webcrypto = require('../src/webcrypto')
+
+describe('Missing web crypto', () => {
+  let webcryptoGet
+  let rsaPrivateKey
+
+  before(done => {
+    crypto.keys.generateKeyPair('RSA', 512, (err, key) => {
+      if (err) return done(err)
+      rsaPrivateKey = key
+      done()
+    })
+  })
+
+  before(() => {
+    webcryptoGet = webcrypto.get
+    webcrypto.get = () => null
+  })
+
+  after(() => {
+    webcrypto.get = webcryptoGet
+  })
+
+  it('should error for hmac create when web crypto is missing', done => {
+    crypto.hmac.create('SHA256', Buffer.from('secret'), err => {
+      expect(err).to.exist()
+      expect(err.code).to.equal('ERR_MISSING_WEB_CRYPTO')
+      done()
+    })
+  })
+
+  it('should error for generate ephemeral key pair when web crypto is missing', done => {
+    crypto.keys.generateEphemeralKeyPair('P-256', err => {
+      expect(err).to.exist()
+      expect(err.code).to.equal('ERR_MISSING_WEB_CRYPTO')
+      done()
+    })
+  })
+
+  it('should error for generate rsa key pair when web crypto is missing', done => {
+    crypto.keys.generateKeyPair('rsa', 256, err => {
+      expect(err).to.exist()
+      expect(err.code).to.equal('ERR_MISSING_WEB_CRYPTO')
+      done()
+    })
+  })
+
+  it('should error for unmarshal RSA private key when web crypto is missing', done => {
+    crypto.keys.unmarshalPrivateKey(crypto.keys.marshalPrivateKey(rsaPrivateKey), err => {
+      expect(err).to.exist()
+      expect(err.code).to.equal('ERR_MISSING_WEB_CRYPTO')
+      done()
+    })
+  })
+
+  it('should error for sign RSA private key when web crypto is missing', done => {
+    rsaPrivateKey.sign(Buffer.from('test'), err => {
+      expect(err).to.exist()
+      expect(err.code).to.equal('ERR_MISSING_WEB_CRYPTO')
+      done()
+    })
+  })
+
+  it('should error for verify RSA public key when web crypto is missing', done => {
+    rsaPrivateKey.public.verify(Buffer.from('test'), Buffer.from('test'), err => {
+      expect(err).to.exist()
+      expect(err.code).to.equal('ERR_MISSING_WEB_CRYPTO')
+      done()
+    })
+  })
+})
+
+describe('BYO web crypto', () => {
+  it('should fallback to self.__crypto if self.crypto is missing', () => {
+    const customCrypto = {}
+    expect(webcrypto.get({ __crypto: customCrypto })).to.equal(customCrypto)
+  })
+})


### PR DESCRIPTION
Changes `webcrypto.js` to check for native web crypto availability and falls back to using `window.__crypto` if not available.

If the user wants to bring their own Web Crypto API compatible implementation then they simply need to assign it to `window.__crypto` before they start using IPFS/libp2p.

Checks are done in the functions that require web crypto to give the user the flexibility to assign to `window.__crypto` before OR after they import `libp2p-crypto`. It also means that users have the ability to use other exported functions that do not require web crypto without having to worry about sorting their own implementation.

We use `window.__crypto` because `window.crypto` is a readonly property in secure context and always readonly in workers.

If `window.crypto` and `window.__cypto` are unavailable then an appropriate error message is reported to the user with a `ERR_MISSING_WEB_CRYPTO` code.

I've also added documentation to the README.

This is a backwards compatible change.

closes https://github.com/libp2p/js-libp2p-crypto/pull/149
resolves https://github.com/libp2p/js-libp2p-crypto/issues/105
resolves https://github.com/ipfs/js-ipfs/issues/2017
resolves https://github.com/ipfs/js-ipfs/issues/2153

cc @lidel