### PR TITLE
Upgrade libp2p-crypto-secp256k1 + fix Secp256k1 tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "bundlesize": "~0.18.0",
     "chai": "^4.2.0",
     "chai-string": "^1.5.0",
-    "dirty-chai": "^2.0.1"
+    "dirty-chai": "^2.0.1",
+    "sinon": "^7.3.2"
   },
   "engines": {
     "node": ">=10.0.0",


### PR DESCRIPTION
Upgrade libp2p-crypto-secp256k1 dependency and ensure that Secp256k1 supported is tested properly.