### PR TITLE
fix: put optional args last for key export

### DIFF
--- a/src/keys/rsa-class.js
+++ b/src/keys/rsa-class.js
@@ -103,16 +103,11 @@ class RsaPrivateKey {
   /**
    * Exports the key into a password protected PEM format
    *
-   * @param {string} [format] - Defaults to 'pkcs-8'.
    * @param {string} password - The password to read the encrypted PEM
+   * @param {string} [format] - Defaults to 'pkcs-8'.
    * @returns {KeyInfo}
    */
-  async export (format, password) { // eslint-disable-line require-await
-    if (password == null) {
-      password = format
-      format = 'pkcs-8'
-    }
-
+  async export (password, format = 'pkcs-8') { // eslint-disable-line require-await
     let pem = null
 
     const buffer = new forge.util.ByteBuffer(this.marshal())

--- a/test/keys/rsa.spec.js
+++ b/test/keys/rsa.spec.js
@@ -88,7 +88,7 @@ describe('RSA', function () {
 
   describe('export and import', () => {
     it('password protected PKCS #8', async () => {
-      const pem = await key.export('pkcs-8', 'my secret')
+      const pem = await key.export('my secret', 'pkcs-8')
       expect(pem).to.startsWith('-----BEGIN ENCRYPTED PRIVATE KEY-----')
       const clone = await crypto.keys.import(pem, 'my secret')
       expect(clone).to.exist()


### PR DESCRIPTION
Fixes https://github.com/libp2p/js-libp2p-crypto/issues/153

Note: This probably isn't going to require any upstream code changes, because there is only one allowed export format and it's the default