### PR TITLE
V0.16.x upgrade node forge

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "keypair": "^1.0.1",
     "libp2p-crypto-secp256k1": "~0.3.0",
     "multihashing-async": "~0.5.1",
-    "node-forge": "~0.7.6",
+    "node-forge": "^0.8.5",
     "pem-jwk": "^2.0.0",
     "protons": "^1.0.1",
     "rsa-pem-to-jwk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "ursa-optional": "~0.9.10"
   },
   "devDependencies": {
-    "aegir": "^18.0.3",
+    "aegir": "^20.0.0",
     "benchmark": "^2.1.4",
-    "bundlesize": "~0.17.0",
+    "bundlesize": "^0.18.0",
     "chai": "^4.2.0",
     "chai-string": "^1.5.0",
     "dirty-chai": "^2.0.1"

--- a/src/keys/index.js
+++ b/src/keys/index.js
@@ -28,7 +28,7 @@ exports.generateEphemeralKeyPair = require('./ephemeral-keys')
 
 // Generates a keypair of the given type and bitsize
 exports.generateKeyPair = (type, bits, cb) => {
-  let key = supportedKeys[type.toLowerCase()]
+  const key = supportedKeys[type.toLowerCase()]
 
   if (!key) {
     return cb(new Error('invalid or unsupported key type'))
@@ -40,7 +40,7 @@ exports.generateKeyPair = (type, bits, cb) => {
 // Generates a keypair of the given type and bitsize
 // seed is a 32 byte uint8array
 exports.generateKeyPairFromSeed = (type, seed, bits, cb) => {
-  let key = supportedKeys[type.toLowerCase()]
+  const key = supportedKeys[type.toLowerCase()]
   if (!key) {
     return cb(new Error('invalid or unsupported key type'))
   }

--- a/src/keys/key-stretcher.js
+++ b/src/keys/key-stretcher.js
@@ -47,7 +47,7 @@ module.exports = (cipherType, hash, secret, callback) => {
         return callback(err)
       }
 
-      let result = []
+      const result = []
       let j = 0
 
       whilst(

--- a/src/util.js
+++ b/src/util.js
@@ -6,7 +6,7 @@ const BN = require('asn1.js').bignum
 // Adapted from https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-41#appendix-C
 exports.toBase64 = function toBase64 (bn, len) {
   // if len is defined then the bytes are leading-0 padded to the length
-  let s = bn.toArrayLike(Buffer, 'be', len).toString('base64')
+  const s = bn.toArrayLike(Buffer, 'be', len).toString('base64')
 
   return s
     .replace(/(=*)$/, '') // Remove any trailing '='s

--- a/test/helpers/test-garbage-error-handling.js
+++ b/test/helpers/test-garbage-error-handling.js
@@ -19,7 +19,7 @@ function doTests (fncName, fnc, num, skipBuffersAndStrings) {
       // skip this garbage because it's a buffer or a string and we were told do do that
       return
     }
-    let args = []
+    const args = []
     for (let i = 0; i < num; i++) {
       args.push(garbage)
     }

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -24,7 +24,7 @@ describe('Util', () => {
   })
 
   it('toBase64 zero padding', (done) => {
-    let bnpad = new BN('ff', 16)
+    const bnpad = new BN('ff', 16)
     expect(util.toBase64(bnpad, 2)).to.eql('AP8')
     done()
   })


### PR DESCRIPTION
Upgrades `node-forge` dependency to the same one used by `libp2p-keychain` in order to downgrade `libp2p-keychain`'s `peer-id` dependency to the same version as the `libp2p` in order to upgrade `ipfs` to use the latest `libp2p` and still be able to dial other nodes on the network.

Phew.

This is necessary because otherwise `node-forge` complains that `sha512` is an unknown hash algorithm.

N.b. this PR is against the branch `v0.16.x` and not master, which is `v0.17.0` so needs to be released as `0.16.2`.

Also upgrades `aegir` to `v20` because for whatever reason the tests weren't running on browsers with `v18` any more.  It upgrades `standard` so there's some refactoring noise in this PR.