### PR TITLE
chore: change lead maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repo contains the JavaScript implementation of the crypto primitives needed
 
 ## Lead Maintainer
 
-[Friedel Ziegelmayer](https://github.com/dignifiedquire/)
+[Jacob Heun](https://github.com/jacobheun/)
 
 ## Table of Contents
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.17.0",
   "description": "Crypto primitives for libp2p",
   "main": "src/index.js",
-  "leadMaintainer": "Friedel Ziegelmayer <dignifiedquire@gmail.com>",
+  "leadMaintainer": "Jacob Heun <jacobheun@gmail.com>",
   "browser": {
     "./src/hmac/index.js": "./src/hmac/index-browser.js",
     "./src/keys/ecdh.js": "./src/keys/ecdh-browser.js",


### PR DESCRIPTION
I am proposing to take over Lead Maintainer of libp2p-crypto.

If approved, I will need npm publish permissions.

- [x] update npm permissions