### PR TITLE
perf: remove jwk2privPem and jwk2pubPem

### DIFF
--- a/src/keys/jwk2pem.js
+++ b/src/keys/jwk2pem.js
@@ -1,10 +1,9 @@
 'use strict'
 
-const forge = {
-  util: require('node-forge/lib/util'),
-  pki: require('node-forge/lib/pki'),
-  jsbn: require('node-forge/lib/jsbn')
-}
+require('node-forge/lib/rsa')
+require('node-forge/lib/util')
+require('node-forge/lib/jsbn')
+const forge = require('node-forge/lib/forge')
 
 function base64urlToBigInteger (str) {
   var bytes = forge.util.decode64(
@@ -22,21 +21,11 @@ function jwk2priv (key) {
   return forge.pki.setRsaPrivateKey(...convert(key, ['n', 'e', 'd', 'p', 'q', 'dp', 'dq', 'qi']))
 }
 
-function jwk2privPem (key) {
-  return forge.pki.privateKeyToPem(jwk2priv(key))
-}
-
 function jwk2pub (key) {
   return forge.pki.setRsaPublicKey(...convert(key, ['n', 'e']))
 }
 
-function jwk2pubPem (key) {
-  return forge.pki.publicKeyToPem(jwk2pub(key))
-}
-
 module.exports = {
   jwk2pub,
-  jwk2pubPem,
-  jwk2priv,
-  jwk2privPem
+  jwk2priv
 }


### PR DESCRIPTION
These two unused functions required us to import the whole of the node-forge PKI implementation when we only use some RSA stuffs.

I thought this was going to lead to a big saving but then I realised that `libp2p-keychain` requires `pkcs7` from `node-forge` which brings in a bunch of other modules...

It saves 34KB, but that only translates to 2KB when minified and gzipped. Still it's something, and I've done the research work now so might as well submit it 🤷‍♂️

---

Before:

<img width="1246" alt="Screenshot 2020-02-02 at 22 28 44" src="https://user-images.githubusercontent.com/152863/73616458-8b11b700-460b-11ea-822f-7026cac379a9.png">

After:

<img width="1244" alt="Screenshot 2020-02-02 at 22 28 54" src="https://user-images.githubusercontent.com/152863/73616460-8ea53e00-460b-11ea-8593-e8498941b811.png">
