### PR TITLE
chore: update node forge version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "keypair": "^1.0.1",
     "multibase": "^0.7.0",
     "multihashing-async": "^0.8.1",
-    "node-forge": "~0.9.1",
+    "node-forge": "^0.9.1",
     "pem-jwk": "^2.0.0",
     "protons": "^1.0.1",
     "secp256k1": "^4.0.0",


### PR DESCRIPTION
I'm seeing two copies of `node-forge` in the js-IPFS bundle, my guess is because libp2p uses a `^` character for version selection and this module uses `~`.

The change here brings the version number into line with libp2p.

![image](https://user-images.githubusercontent.com/665810/84128737-df54f980-aa38-11ea-91f3-53067c6e04df.png)
