### PR TITLE
feat: add exporting/importing of non rsa keys in libp2p-key format

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,14 +262,23 @@ Returns `Promise<RsaPrivateKey|Ed25519PrivateKey|Secp256k1PrivateKey>`
 
 Converts a protobuf serialized private key into its representative object.
 
-### `crypto.keys.import(pem, password)`
+### `crypto.keys.import(encryptedKey, password)`
 
-- `pem: string`
+- `encryptedKey: string`
 - `password: string`
 
-Returns `Promise<RsaPrivateKey>`
+Returns `Promise<PrivateKey>`
 
-Converts a PEM password protected private key into its representative object.
+Converts an exported private key into its representative object. Supported formats are 'pem' (RSA only) and 'libp2p-key'.
+
+### `privateKey.export(password, format)`
+
+- `password: string`
+- `format: string` the format to export to: 'pem' (rsa only), 'libp2p-key'
+
+Returns `string`
+
+Exports the password protected `PrivateKey`. RSA keys will be exported as password protected PEM by default. Ed25519 and Secp256k1 keys will be exported as password protected AES-GCM base64 encoded strings ('libp2p-key' format).
 
 ### `crypto.randomBytes(number)`
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/dirty-chai": "^2.0.2",
     "@types/mocha": "^8.0.0",
     "@types/sinon": "^9.0.0",
-    "aegir": "^22.0.0",
+    "aegir": "^25.0.0",
     "benchmark": "^2.1.4",
     "chai": "^4.2.0",
     "chai-string": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "pem-jwk": "^2.0.0",
     "protons": "^1.2.1",
     "secp256k1": "^4.0.0",
+    "uint8arrays": "^1.0.0",
     "ursa-optional": "^0.10.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "types": "src/index.d.ts",
   "leadMaintainer": "Jacob Heun <jacobheun@gmail.com>",
   "browser": {
+    "./src/aes/ciphers.js": "./src/aes/ciphers-browser.js",
+    "./src/ciphers/aes-gcm.js": "./src/ciphers/aes-gcm.browser.js",
     "./src/hmac/index.js": "./src/hmac/index-browser.js",
     "./src/keys/ecdh.js": "./src/keys/ecdh-browser.js",
-    "./src/aes/ciphers.js": "./src/aes/ciphers-browser.js",
     "./src/keys/rsa.js": "./src/keys/rsa-browser.js"
   },
   "files": [
@@ -55,7 +56,7 @@
     "@types/chai": "^4.2.11",
     "@types/chai-string": "^1.4.2",
     "@types/dirty-chai": "^2.0.2",
-    "@types/mocha": "^7.0.1",
+    "@types/mocha": "^8.0.0",
     "@types/sinon": "^9.0.0",
     "aegir": "^22.0.0",
     "benchmark": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "is-typedarray": "^1.0.0",
     "iso-random-stream": "^1.1.0",
     "keypair": "^1.0.1",
-    "multibase": "^0.7.0",
+    "multibase": "^1.0.1",
+    "multicodec": "^1.0.4",
     "multihashing-async": "^0.8.1",
     "node-forge": "^0.9.1",
     "pem-jwk": "^2.0.0",
@@ -53,11 +54,10 @@
     "ursa-optional": "^0.10.1"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.11",
+    "@types/chai": "^4.2.12",
     "@types/chai-string": "^1.4.2",
     "@types/dirty-chai": "^2.0.2",
-    "@types/mocha": "^8.0.0",
-    "@types/sinon": "^9.0.0",
+    "@types/mocha": "^8.0.1",
     "aegir": "^25.0.0",
     "benchmark": "^2.1.4",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "multihashing-async": "^0.8.1",
     "node-forge": "^0.9.1",
     "pem-jwk": "^2.0.0",
-    "protons": "^1.0.1",
+    "protons": "^1.2.1",
     "secp256k1": "^4.0.0",
-    "ursa-optional": "~0.10.1"
+    "ursa-optional": "^0.10.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/src/ciphers/aes-gcm.browser.js
+++ b/src/ciphers/aes-gcm.browser.js
@@ -1,0 +1,119 @@
+'use strict'
+
+const webcrypto = require('../webcrypto')
+
+// Based off of code from https://github.com/luke-park/SecureCompatibleEncryptionExamples
+
+/**
+ *
+ * @param {object} param0
+ * @param {string} [param0.algorithm] Defaults to 'aes-128-gcm'
+ * @param {Number} [param0.nonceLength] Defaults to 12 (96-bit)
+ * @param {Number} [param0.keyLength] Defaults to 16
+ * @param {string} [param0.digest] Defaults to 'sha256'
+ * @param {Number} [param0.saltLength] Defaults to 16
+ * @param {Number} [param0.iterations] Defaults to 32767
+ * @returns {*}
+ */
+function create ({
+  algorithm = 'AES-GCM',
+  nonceLength = 12,
+  keyLength = 16,
+  digest = 'SHA-256',
+  saltLength = 16,
+  iterations = 32767
+} = {}) {
+  const crypto = webcrypto.get()
+  keyLength *= 8 // Browser crypto uses bits instead of bytes
+
+  /**
+   *
+   * @param {Uint8Array} data
+   * @param {*} key
+   */
+  async function encryptWithKey (data, key) { // eslint-disable-line require-await
+    const nonce = crypto.getRandomValues(new Uint8Array(nonceLength))
+    const aesGcm = { name: algorithm, iv: nonce }
+
+    // Create a 'CryptoKey'.
+    const cryptoKey = await crypto.subtle.importKey('raw', key, aesGcm, false, ['encrypt'])
+
+    // Encrypt.
+    const ciphertext = await crypto.subtle.encrypt(aesGcm, cryptoKey, data)
+    return joinBuffers(aesGcm.iv, new Uint8Array(ciphertext))
+  }
+
+  /**
+   *
+   * @param {Uint8Array} data The data to decrypt
+   * @param {string} password A plain password
+   */
+  async function encrypt (data, password) { // eslint-disable-line require-await
+    const salt = crypto.getRandomValues(new Uint8Array(saltLength))
+    const nonce = crypto.getRandomValues(new Uint8Array(nonceLength))
+    const aesGcm = { name: algorithm, iv: nonce }
+
+    // Derive a key using PBKDF2.
+    const deriveParams = { name: 'PBKDF2', salt, iterations, hash: { name: digest } }
+    const rawKey = await crypto.subtle.importKey('raw', (new TextEncoder()).encode(password), { name: 'PBKDF2' }, false, ['deriveKey', 'deriveBits'])
+    const cryptoKey = await crypto.subtle.deriveKey(deriveParams, rawKey, { name: algorithm, length: keyLength }, true, ['encrypt'])
+
+    // Encrypt the string.
+    const ciphertext = await crypto.subtle.encrypt(aesGcm, cryptoKey, data)
+    return joinBuffers(salt, joinBuffers(aesGcm.iv, new Uint8Array(ciphertext)))
+  }
+
+  async function decrypt (data, password) {
+    const salt = data.slice(0, saltLength)
+    const nonce = data.slice(saltLength, saltLength + nonceLength)
+    const ciphertext = data.slice(saltLength + nonceLength)
+    const aesGcm = { name: algorithm, iv: nonce }
+
+    // Derive the key using PBKDF2.
+    const deriveParams = { name: 'PBKDF2', salt, iterations, hash: { name: digest } }
+    const rawKey = await crypto.subtle.importKey('raw', (new TextEncoder()).encode(password), { name: 'PBKDF2' }, false, ['deriveKey', 'deriveBits'])
+    const cryptoKey = await crypto.subtle.deriveKey(deriveParams, rawKey, { name: algorithm, length: keyLength }, true, ['decrypt'])
+
+    // Decrypt the string.
+    const plaintext = await crypto.subtle.decrypt(aesGcm, cryptoKey, ciphertext)
+    return new Uint8Array(plaintext)
+  }
+
+  async function decryptWithKey (data, key) {
+    const nonce = data.slice(0, nonceLength)
+    const ciphertext = data.slice(nonceLength)
+
+    const aesGcm = { name: algorithm, iv: nonce }
+
+    // Create the 'CryptoKey'.
+    const cryptoKey = await crypto.subtle.importKey('raw', key, aesGcm, false, ['decrypt'])
+
+    // Decrypt the string.
+    const plaintext = await crypto.subtle.decrypt(aesGcm, cryptoKey, ciphertext)
+    return new Uint8Array(plaintext)
+  }
+
+  return {
+    encrypt,
+    encryptWithKey,
+    decrypt,
+    decryptWithKey
+  }
+}
+
+function joinBuffers (a, b) {
+  const c = new Uint8Array(a.byteLength + b.byteLength)
+
+  for (let i = 0; i < a.length; i++) {
+    c[i] = a[i]
+  }
+  for (let i = 0; i < b.length; i++) {
+    c[i + a.length] = b[i]
+  }
+
+  return c
+}
+
+module.exports = {
+  create
+}

--- a/src/ciphers/aes-gcm.browser.js
+++ b/src/ciphers/aes-gcm.browser.js
@@ -9,13 +9,13 @@ const webcrypto = require('../webcrypto')
 
 /**
  *
- * @param {object} param0
- * @param {string} [param0.algorithm] Defaults to 'aes-128-gcm'
- * @param {Number} [param0.nonceLength] Defaults to 12 (96-bit)
- * @param {Number} [param0.keyLength] Defaults to 16
- * @param {string} [param0.digest] Defaults to 'sha256'
- * @param {Number} [param0.saltLength] Defaults to 16
- * @param {Number} [param0.iterations] Defaults to 32767
+ * @param {object} [options]
+ * @param {string} [options.algorithm=AES-GCM]
+ * @param {Number} [options.nonceLength=12]
+ * @param {Number} [options.keyLength=16]
+ * @param {string} [options.digest=sha256]
+ * @param {Number} [options.saltLength=16]
+ * @param {Number} [options.iterations=32767]
  * @returns {*}
  */
 function create ({

--- a/src/ciphers/aes-gcm.browser.js
+++ b/src/ciphers/aes-gcm.browser.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const concat = require('uint8arrays/concat')
+const fromString = require('uint8arrays/from-string')
+
 const webcrypto = require('../webcrypto')
 
 // Based off of code from https://github.com/luke-park/SecureCompatibleEncryptionExamples
@@ -27,9 +30,12 @@ function create ({
   keyLength *= 8 // Browser crypto uses bits instead of bytes
 
   /**
+   * Uses the provided password to derive a pbkdf2 key. The key
+   * will then be used to encrypt the data.
    *
    * @param {Uint8Array} data The data to decrypt
    * @param {string} password A plain password
+   * @returns {Promise<Uint8Array>}
    */
   async function encrypt (data, password) { // eslint-disable-line require-await
     const salt = crypto.getRandomValues(new Uint8Array(saltLength))
@@ -38,14 +44,24 @@ function create ({
 
     // Derive a key using PBKDF2.
     const deriveParams = { name: 'PBKDF2', salt, iterations, hash: { name: digest } }
-    const rawKey = await crypto.subtle.importKey('raw', (new TextEncoder()).encode(password), { name: 'PBKDF2' }, false, ['deriveKey', 'deriveBits'])
+    const rawKey = await crypto.subtle.importKey('raw', fromString(password), { name: 'PBKDF2' }, false, ['deriveKey', 'deriveBits'])
     const cryptoKey = await crypto.subtle.deriveKey(deriveParams, rawKey, { name: algorithm, length: keyLength }, true, ['encrypt'])
 
     // Encrypt the string.
     const ciphertext = await crypto.subtle.encrypt(aesGcm, cryptoKey, data)
-    return joinBuffers(salt, joinBuffers(aesGcm.iv, new Uint8Array(ciphertext)))
+    return concat([salt, aesGcm.iv, new Uint8Array(ciphertext)])
   }
 
+  /**
+   * Uses the provided password to derive a pbkdf2 key. The key
+   * will then be used to decrypt the data. The options used to create
+   * this decryption cipher must be the same as those used to create
+   * the encryption cipher.
+   *
+   * @param {Uint8Array} data The data to decrypt
+   * @param {string} password A plain password
+   * @returns {Promise<Uint8Array>}
+   */
   async function decrypt (data, password) {
     const salt = data.slice(0, saltLength)
     const nonce = data.slice(saltLength, saltLength + nonceLength)
@@ -54,7 +70,7 @@ function create ({
 
     // Derive the key using PBKDF2.
     const deriveParams = { name: 'PBKDF2', salt, iterations, hash: { name: digest } }
-    const rawKey = await crypto.subtle.importKey('raw', (new TextEncoder()).encode(password), { name: 'PBKDF2' }, false, ['deriveKey', 'deriveBits'])
+    const rawKey = await crypto.subtle.importKey('raw', fromString(password), { name: 'PBKDF2' }, false, ['deriveKey', 'deriveBits'])
     const cryptoKey = await crypto.subtle.deriveKey(deriveParams, rawKey, { name: algorithm, length: keyLength }, true, ['decrypt'])
 
     // Decrypt the string.
@@ -66,19 +82,6 @@ function create ({
     encrypt,
     decrypt
   }
-}
-
-function joinBuffers (a, b) {
-  const c = new Uint8Array(a.byteLength + b.byteLength)
-
-  for (let i = 0; i < a.length; i++) {
-    c[i] = a[i]
-  }
-  for (let i = 0; i < b.length; i++) {
-    c[i + a.length] = b[i]
-  }
-
-  return c
 }
 
 module.exports = {

--- a/src/ciphers/aes-gcm.browser.js
+++ b/src/ciphers/aes-gcm.browser.js
@@ -28,23 +28,6 @@ function create ({
 
   /**
    *
-   * @param {Uint8Array} data
-   * @param {*} key
-   */
-  async function encryptWithKey (data, key) { // eslint-disable-line require-await
-    const nonce = crypto.getRandomValues(new Uint8Array(nonceLength))
-    const aesGcm = { name: algorithm, iv: nonce }
-
-    // Create a 'CryptoKey'.
-    const cryptoKey = await crypto.subtle.importKey('raw', key, aesGcm, false, ['encrypt'])
-
-    // Encrypt.
-    const ciphertext = await crypto.subtle.encrypt(aesGcm, cryptoKey, data)
-    return joinBuffers(aesGcm.iv, new Uint8Array(ciphertext))
-  }
-
-  /**
-   *
    * @param {Uint8Array} data The data to decrypt
    * @param {string} password A plain password
    */
@@ -79,25 +62,9 @@ function create ({
     return new Uint8Array(plaintext)
   }
 
-  async function decryptWithKey (data, key) {
-    const nonce = data.slice(0, nonceLength)
-    const ciphertext = data.slice(nonceLength)
-
-    const aesGcm = { name: algorithm, iv: nonce }
-
-    // Create the 'CryptoKey'.
-    const cryptoKey = await crypto.subtle.importKey('raw', key, aesGcm, false, ['decrypt'])
-
-    // Decrypt the string.
-    const plaintext = await crypto.subtle.decrypt(aesGcm, cryptoKey, ciphertext)
-    return new Uint8Array(plaintext)
-  }
-
   return {
     encrypt,
-    encryptWithKey,
-    decrypt,
-    decryptWithKey
+    decrypt
   }
 }
 

--- a/src/ciphers/aes-gcm.js
+++ b/src/ciphers/aes-gcm.js
@@ -7,7 +7,6 @@ const crypto = require('crypto')
 /**
  *
  * @param {object} param0
- * @param {string} [param0.algorithm] Defaults to 'aes-128-gcm'
  * @param {Number} [param0.algorithmTagLength] Defaults to 16
  * @param {Number} [param0.nonceLength] Defaults to 12 (96-bit)
  * @param {Number} [param0.keyLength] Defaults to 16
@@ -17,7 +16,6 @@ const crypto = require('crypto')
  * @returns {*}
  */
 function create ({
-  algorithm = 'aes-128-gcm',
   algorithmTagLength = 16,
   nonceLength = 12,
   keyLength = 16,
@@ -25,6 +23,7 @@ function create ({
   saltLength = 16,
   iterations = 32767
 } = {}) {
+  const algorithm = 'aes-128-gcm'
   /**
    *
    * @param {Buffer} data

--- a/src/ciphers/aes-gcm.js
+++ b/src/ciphers/aes-gcm.js
@@ -26,8 +26,10 @@ function create ({
   const algorithm = 'aes-128-gcm'
   /**
    *
+   * @private
    * @param {Buffer} data
-   * @param {*} key
+   * @param {Buffer} key
+   * @returns {Promise<Buffer>}
    */
   async function encryptWithKey (data, key) { // eslint-disable-line require-await
     const nonce = crypto.randomBytes(nonceLength)
@@ -42,9 +44,12 @@ function create ({
   }
 
   /**
+   * Uses the provided password to derive a pbkdf2 key. The key
+   * will then be used to encrypt the data.
    *
    * @param {Buffer} data The data to decrypt
    * @param {string|Buffer} password A plain password
+   * @returns {Promise<Buffer>}
    */
   async function encrypt (data, password) { // eslint-disable-line require-await
     // Generate a 128-bit salt using a CSPRNG.
@@ -64,8 +69,10 @@ function create ({
    * this decryption cipher must be the same as those used to create
    * the encryption cipher.
    *
+   * @private
    * @param {Buffer} ciphertextAndNonce The data to decrypt
    * @param {Buffer} key
+   * @returns {Promise<Buffer>}
    */
   async function decryptWithKey (ciphertextAndNonce, key) { // eslint-disable-line require-await
     // Create buffers of nonce, ciphertext and tag.

--- a/src/ciphers/aes-gcm.js
+++ b/src/ciphers/aes-gcm.js
@@ -1,0 +1,116 @@
+'use strict'
+
+const crypto = require('crypto')
+
+// Based off of code from https://github.com/luke-park/SecureCompatibleEncryptionExamples
+
+/**
+ *
+ * @param {object} param0
+ * @param {string} [param0.algorithm] Defaults to 'aes-128-gcm'
+ * @param {Number} [param0.algorithmTagLength] Defaults to 16
+ * @param {Number} [param0.nonceLength] Defaults to 12 (96-bit)
+ * @param {Number} [param0.keyLength] Defaults to 16
+ * @param {string} [param0.digest] Defaults to 'sha256'
+ * @param {Number} [param0.saltLength] Defaults to 16
+ * @param {Number} [param0.iterations] Defaults to 32767
+ * @returns {*}
+ */
+function create ({
+  algorithm = 'aes-128-gcm',
+  algorithmTagLength = 16,
+  nonceLength = 12,
+  keyLength = 16,
+  digest = 'sha256',
+  saltLength = 16,
+  iterations = 32767
+} = {}) {
+  /**
+   *
+   * @param {Buffer} data
+   * @param {*} key
+   */
+  async function encryptWithKey (data, key) { // eslint-disable-line require-await
+    const nonce = crypto.randomBytes(nonceLength)
+
+    // Create the cipher instance.
+    const cipher = crypto.createCipheriv(algorithm, key, nonce)
+
+    // Encrypt and prepend nonce.
+    const ciphertext = Buffer.concat([cipher.update(data), cipher.final()])
+
+    return Buffer.concat([nonce, ciphertext, cipher.getAuthTag()])
+  }
+
+  /**
+   *
+   * @param {Buffer} data The data to decrypt
+   * @param {string|Buffer} password A plain password
+   */
+  async function encrypt (data, password) { // eslint-disable-line require-await
+    // Generate a 128-bit salt using a CSPRNG.
+    const salt = crypto.randomBytes(saltLength)
+
+    // Derive a key using PBKDF2.
+    const key = crypto.pbkdf2Sync(Buffer.from(password), salt, iterations, keyLength, digest)
+
+    // Encrypt and prepend salt.
+    return Buffer.concat([salt, await encryptWithKey(Buffer.from(data), key)])
+  }
+
+  /**
+   * Decrypts the given cipher text with the provided key. The `key` should
+   * be a cryptographically safe key and not a plaintext password. To use
+   * a plaintext password, use `decrypt`. The options used to create
+   * this decryption cipher must be the same as those used to create
+   * the encryption cipher.
+   *
+   * @param {Buffer} ciphertextAndNonce The data to decrypt
+   * @param {Buffer} key
+   */
+  async function decryptWithKey (ciphertextAndNonce, key) { // eslint-disable-line require-await
+    // Create buffers of nonce, ciphertext and tag.
+    const nonce = ciphertextAndNonce.slice(0, nonceLength)
+    const ciphertext = ciphertextAndNonce.slice(nonceLength, ciphertextAndNonce.length - algorithmTagLength)
+    const tag = ciphertextAndNonce.slice(ciphertext.length + nonceLength)
+
+    // Create the cipher instance.
+    const cipher = crypto.createDecipheriv(algorithm, key, nonce)
+
+    // Decrypt and return result.
+    cipher.setAuthTag(tag)
+    return Buffer.concat([cipher.update(ciphertext), cipher.final()])
+  }
+
+  /**
+   * Uses the provided password to derive a pbkdf2 key. The key
+   * will then be used to decrypt the data. The options used to create
+   * this decryption cipher must be the same as those used to create
+   * the encryption cipher.
+   *
+   * @param {Buffer} data The data to decrypt
+   * @param {string|Buffer} password A plain password
+   */
+  async function decrypt (data, password) { // eslint-disable-line require-await
+    // Create buffers of salt and ciphertextAndNonce.
+    const salt = data.slice(0, saltLength)
+    const ciphertextAndNonce = data.slice(saltLength)
+
+    // Derive the key using PBKDF2.
+    const key = crypto.pbkdf2Sync(Buffer.from(password), salt, iterations, keyLength, digest)
+
+    // Decrypt and return result.
+    return decryptWithKey(ciphertextAndNonce, key)
+  }
+
+  return {
+    encrypt,
+    encryptWithKey,
+    decrypt,
+    decryptWithKey
+  }
+}
+
+module.exports = {
+  create
+}

--- a/src/ciphers/aes-gcm.js
+++ b/src/ciphers/aes-gcm.js
@@ -104,9 +104,7 @@ function create ({
 
   return {
     encrypt,
-    encryptWithKey,
-    decrypt,
-    decryptWithKey
+    decrypt
   }
 }
 

--- a/src/ciphers/aes-gcm.js
+++ b/src/ciphers/aes-gcm.js
@@ -6,13 +6,13 @@ const crypto = require('crypto')
 
 /**
  *
- * @param {object} param0
- * @param {Number} [param0.algorithmTagLength] Defaults to 16
- * @param {Number} [param0.nonceLength] Defaults to 12 (96-bit)
- * @param {Number} [param0.keyLength] Defaults to 16
- * @param {string} [param0.digest] Defaults to 'sha256'
- * @param {Number} [param0.saltLength] Defaults to 16
- * @param {Number} [param0.iterations] Defaults to 32767
+ * @param {object} [options]
+ * @param {Number} [options.algorithmTagLength=16]
+ * @param {Number} [options.nonceLength=12]
+ * @param {Number} [options.keyLength=16]
+ * @param {string} [options.digest=sha256]
+ * @param {Number} [options.saltLength=16]
+ * @param {Number} [options.iterations=32767]
  * @returns {*}
  */
 function create ({

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -76,6 +76,9 @@ export interface PublicKey {
   hash(): Promise<Buffer>;
 }
 
+// Type alias for export method
+export type KeyInfo = any;
+
 /**
  * Generic private key interface.
  */
@@ -94,6 +97,13 @@ export interface PrivateKey {
    * of the PKCS SubjectPublicKeyInfo.
    */
   id(): Promise<string>;
+  /**
+   * Exports the key into a password protected PEM format
+   *
+   * @param password The password to read the encrypted PEM
+   * @param format Defaults to 'pkcs-8'.
+   */
+  export(password: string, format?: "pkcs-8" | string): Promise<KeyInfo>;
 }
 
 export interface Keystretcher {
@@ -132,9 +142,6 @@ export namespace keys {
         hash(): Promise<Buffer>;
       }
 
-      // Type alias for export method
-      export type KeyInfo = any;
-
       class RsaPrivateKey implements PrivateKey {
         constructor(key: any, publicKey: Buffer);
         readonly public: RsaPublicKey;
@@ -146,13 +153,7 @@ export namespace keys {
         equals(key: PrivateKey): boolean;
         hash(): Promise<Buffer>;
         id(): Promise<string>;
-        /**
-         * Exports the key into a password protected PEM format
-         *
-         * @param password The password to read the encrypted PEM
-         * @param format Defaults to 'pkcs-8'.
-         */
-        export(password: string, format?: "pkcs-8" | string): KeyInfo;
+        export(password: string, format?: string): Promise<KeyInfo>;
       }
       function unmarshalRsaPublicKey(buf: Buffer): RsaPublicKey;
       function unmarshalRsaPrivateKey(buf: Buffer): Promise<RsaPrivateKey>;
@@ -180,6 +181,7 @@ export namespace keys {
         equals(key: PrivateKey): boolean;
         hash(): Promise<Buffer>;
         id(): Promise<string>;
+        export(password: string, format?: string): Promise<KeyInfo>;
       }
 
       function unmarshalEd25519PrivateKey(
@@ -212,6 +214,7 @@ export namespace keys {
         equals(key: PrivateKey): boolean;
         hash(): Promise<Buffer>;
         id(): Promise<string>;
+        export(password: string, format?: string): Promise<KeyInfo>;
       }
 
       function unmarshalSecp256k1PrivateKey(
@@ -234,16 +237,14 @@ export namespace keys {
     bits: number
   ): Promise<PrivateKey>;
   export function generateKeyPair(
-    type: "Ed25519",
-    bits: number
+    type: "Ed25519"
   ): Promise<keys.supportedKeys.ed25519.Ed25519PrivateKey>;
-    export function generateKeyPair(
+  export function generateKeyPair(
     type: "RSA",
     bits: number
   ): Promise<keys.supportedKeys.rsa.RsaPrivateKey>;
-    export function generateKeyPair(
-    type: "secp256k1",
-    bits: number
+  export function generateKeyPair(
+    type: "secp256k1"
   ): Promise<keys.supportedKeys.secp256k1.Secp256k1PrivateKey>;
 
   /**
@@ -318,7 +319,7 @@ export namespace keys {
    * @param pem Password protected private key in PEM format.
    * @param password The password used to protect the key.
    */
-  function _import(pem: string, password: string): Promise<supportedKeys.rsa.RsaPrivateKey>;
+  function _import(pem: string, password: string, format?: string): Promise<supportedKeys.rsa.RsaPrivateKey>;
   export { _import as import };
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -76,9 +76,6 @@ export interface PublicKey {
   hash(): Promise<Buffer>;
 }
 
-// Type alias for export method
-export type KeyInfo = any;
-
 /**
  * Generic private key interface.
  */
@@ -98,12 +95,9 @@ export interface PrivateKey {
    */
   id(): Promise<string>;
   /**
-   * Exports the key into a password protected PEM format
-   *
-   * @param password The password to read the encrypted PEM
-   * @param format Defaults to 'pkcs-8'.
+   * Exports the password protected key in the format specified.
    */
-  export(password: string, format?: "pkcs-8" | string): Promise<KeyInfo>;
+  export(password: string, format?: "pkcs-8" | string): Promise<string>;
 }
 
 export interface Keystretcher {
@@ -153,7 +147,7 @@ export namespace keys {
         equals(key: PrivateKey): boolean;
         hash(): Promise<Buffer>;
         id(): Promise<string>;
-        export(password: string, format?: string): Promise<KeyInfo>;
+        export(password: string, format?: string): Promise<string>;
       }
       function unmarshalRsaPublicKey(buf: Buffer): RsaPublicKey;
       function unmarshalRsaPrivateKey(buf: Buffer): Promise<RsaPrivateKey>;
@@ -181,7 +175,7 @@ export namespace keys {
         equals(key: PrivateKey): boolean;
         hash(): Promise<Buffer>;
         id(): Promise<string>;
-        export(password: string, format?: string): Promise<KeyInfo>;
+        export(password: string, format?: string): Promise<string>;
       }
 
       function unmarshalEd25519PrivateKey(
@@ -214,7 +208,7 @@ export namespace keys {
         equals(key: PrivateKey): boolean;
         hash(): Promise<Buffer>;
         id(): Promise<string>;
-        export(password: string, format?: string): Promise<KeyInfo>;
+        export(password: string, format?: string): Promise<string>;
       }
 
       function unmarshalSecp256k1PrivateKey(

--- a/src/keys/ed25519-class.js
+++ b/src/keys/ed25519-class.js
@@ -8,7 +8,7 @@ const errcode = require('err-code')
 
 const crypto = require('./ed25519')
 const pbm = protobuf(require('./keys.proto'))
-const cipher = require('../ciphers/aes-gcm').create()
+const ciphers = require('../ciphers/aes-gcm')
 
 class Ed25519PublicKey {
   constructor (key) {
@@ -97,6 +97,7 @@ class Ed25519PrivateKey {
    */
   async export (password, format = 'libp2p-key') { // eslint-disable-line require-await
     if (format === 'libp2p-key') {
+      const cipher = ciphers.create()
       return cipher.encrypt(this.bytes, password)
     } else {
       throw errcode(new Error(`export format '${format}' is not supported`), 'ERR_INVALID_EXPORT_FORMAT')

--- a/src/keys/ed25519-class.js
+++ b/src/keys/ed25519-class.js
@@ -92,7 +92,7 @@ class Ed25519PrivateKey {
    * Exports the key into a password protected `format`
    *
    * @param {string} password - The password to encrypt the key
-   * @param {string} [format] - Defaults to 'libp2p-key'.
+   * @param {string} [format=libp2p-key] - The format in which to export as
    * @returns {Promise<Buffer>} The encrypted private key
    */
   async export (password, format = 'libp2p-key') { // eslint-disable-line require-await

--- a/src/keys/ed25519-class.js
+++ b/src/keys/ed25519-class.js
@@ -8,7 +8,7 @@ const errcode = require('err-code')
 
 const crypto = require('./ed25519')
 const pbm = protobuf(require('./keys.proto'))
-const ciphers = require('../ciphers/aes-gcm')
+const exporter = require('./exporter')
 
 class Ed25519PublicKey {
   constructor (key) {
@@ -97,8 +97,7 @@ class Ed25519PrivateKey {
    */
   async export (password, format = 'libp2p-key') { // eslint-disable-line require-await
     if (format === 'libp2p-key') {
-      const cipher = ciphers.create()
-      return cipher.encrypt(this.bytes, password)
+      return exporter.export(this.bytes, password)
     } else {
       throw errcode(new Error(`export format '${format}' is not supported`), 'ERR_INVALID_EXPORT_FORMAT')
     }

--- a/src/keys/exporter.js
+++ b/src/keys/exporter.js
@@ -16,7 +16,7 @@ module.exports = {
   export: async function (privateKey, password) {
     const cipher = ciphers.create()
     const encryptedKey = await cipher.encrypt(privateKey, password)
-    const base64 = multibase.names['base64']
+    const base64 = multibase.names.base64
     return base64.encode(encryptedKey)
   }
 }

--- a/src/keys/exporter.js
+++ b/src/keys/exporter.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const multibase = require('multibase')
+const ciphers = require('../ciphers/aes-gcm')
+
+module.exports = {
+  /**
+   * Exports the given PrivateKey as a base64 encoded string.
+   * The PrivateKey is encrypted via a password derived PBKDF2 key
+   * leveraging the aes-gcm cipher algorithm.
+   *
+   * @param {Buffer} privateKey The PrivateKey protobuf buffer
+   * @param {string} password
+   * @returns {Promise<string>} A base64 encoded string
+   */
+  export: async function (privateKey, password) {
+    const cipher = ciphers.create()
+    const encryptedKey = await cipher.encrypt(privateKey, password)
+    const base64 = multibase.names['base64']
+    return base64.encode(encryptedKey)
+  }
+}

--- a/src/keys/importer.js
+++ b/src/keys/importer.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const multibase = require('multibase')
+const ciphers = require('../ciphers/aes-gcm')
+
+module.exports = {
+  /**
+   * Attempts to decrypt a base64 encoded PrivateKey string
+   * with the given password. The privateKey must have been exported
+   * using the same password and underlying cipher (aes-gcm)
+   *
+   * @param {string} privateKey A base64 encoded encrypted key
+   * @param {string} password
+   * @returns {Promise<Buffer>} The private key protobuf buffer
+   */
+  import: async function (privateKey, password) {
+    const base64 = multibase.names['base64']
+    const encryptedKey = base64.decode(privateKey)
+    const cipher = ciphers.create()
+    return await cipher.decrypt(encryptedKey, password)
+  }
+}

--- a/src/keys/importer.js
+++ b/src/keys/importer.js
@@ -14,7 +14,7 @@ module.exports = {
    * @returns {Promise<Buffer>} The private key protobuf buffer
    */
   import: async function (privateKey, password) {
-    const base64 = multibase.names['base64']
+    const base64 = multibase.names.base64
     const encryptedKey = base64.decode(privateKey)
     const cipher = ciphers.create()
     return await cipher.decrypt(encryptedKey, password)

--- a/src/keys/index.js
+++ b/src/keys/index.js
@@ -119,7 +119,6 @@ exports.marshalPrivateKey = (key, type) => {
 exports.import = async (encryptedKey, password) => { // eslint-disable-line require-await
   try {
     const key = await importer.import(encryptedKey, password)
-    console.log(key)
     return exports.unmarshalPrivateKey(key)
   } catch (_) {
     // Ignore and try the old pem decrypt

--- a/src/keys/rsa-class.js
+++ b/src/keys/rsa-class.js
@@ -111,11 +111,9 @@ class RsaPrivateKey {
    * Exports the key into a password protected PEM format
    *
    * @param {string} password - The password to read the encrypted PEM
-   * @param {string} [format] - Defaults to 'pkcs-8'.
+   * @param {string} [format=pkcs-8] - The format in which to export as
    */
   async export (password, format = 'pkcs-8') { // eslint-disable-line require-await
-    let key = null
-
     if (format === 'pkcs-8') {
       const buffer = new forge.util.ByteBuffer(this.marshal())
       const asn1 = forge.asn1.fromDer(buffer)
@@ -127,14 +125,12 @@ class RsaPrivateKey {
         saltSize: 128 / 8,
         prfAlgorithm: 'sha512'
       }
-      key = forge.pki.encryptRsaPrivateKey(privateKey, password, options)
+      return forge.pki.encryptRsaPrivateKey(privateKey, password, options)
     } else if (format === 'libp2p-key') {
       return exporter.export(this.bytes, password)
     } else {
       throw errcode(new Error(`export format '${format}' is not supported`), 'ERR_INVALID_EXPORT_FORMAT')
     }
-
-    return key
   }
 }
 

--- a/src/keys/rsa-class.js
+++ b/src/keys/rsa-class.js
@@ -5,11 +5,13 @@ const protobuf = require('protons')
 const multibase = require('multibase')
 const errcode = require('err-code')
 
-const crypto = require('./rsa')
-const pbm = protobuf(require('./keys.proto'))
 require('node-forge/lib/sha512')
 require('node-forge/lib/ed25519')
 const forge = require('node-forge/lib/forge')
+
+const crypto = require('./rsa')
+const pbm = protobuf(require('./keys.proto'))
+const ciphers = require('../ciphers/aes-gcm')
 
 class RsaPublicKey {
   constructor (key) {
@@ -112,25 +114,28 @@ class RsaPrivateKey {
    * @param {string} [format] - Defaults to 'pkcs-8'.
    */
   async export (password, format = 'pkcs-8') { // eslint-disable-line require-await
-    let pem = null
-
-    const buffer = new forge.util.ByteBuffer(this.marshal())
-    const asn1 = forge.asn1.fromDer(buffer)
-    const privateKey = forge.pki.privateKeyFromAsn1(asn1)
+    let key = null
 
     if (format === 'pkcs-8') {
+      const buffer = new forge.util.ByteBuffer(this.marshal())
+      const asn1 = forge.asn1.fromDer(buffer)
+      const privateKey = forge.pki.privateKeyFromAsn1(asn1)
+
       const options = {
         algorithm: 'aes256',
         count: 10000,
         saltSize: 128 / 8,
         prfAlgorithm: 'sha512'
       }
-      pem = forge.pki.encryptRsaPrivateKey(privateKey, password, options)
+      key = forge.pki.encryptRsaPrivateKey(privateKey, password, options)
+    } else if (format === 'libp2p-key') {
+      const cipher = ciphers.create()
+      return cipher.encrypt(this.bytes, password)
     } else {
-      throw errcode(new Error(`Unknown export format '${format}'. Must be pkcs-8`), 'ERR_INVALID_EXPORT_FORMAT')
+      throw errcode(new Error(`export format '${format}' is not supported`), 'ERR_INVALID_EXPORT_FORMAT')
     }
 
-    return pem
+    return key
   }
 }
 

--- a/src/keys/rsa-class.js
+++ b/src/keys/rsa-class.js
@@ -11,7 +11,7 @@ const forge = require('node-forge/lib/forge')
 
 const crypto = require('./rsa')
 const pbm = protobuf(require('./keys.proto'))
-const ciphers = require('../ciphers/aes-gcm')
+const exporter = require('./exporter')
 
 class RsaPublicKey {
   constructor (key) {
@@ -129,8 +129,7 @@ class RsaPrivateKey {
       }
       key = forge.pki.encryptRsaPrivateKey(privateKey, password, options)
     } else if (format === 'libp2p-key') {
-      const cipher = ciphers.create()
-      return cipher.encrypt(this.bytes, password)
+      return exporter.export(this.bytes, password)
     } else {
       throw errcode(new Error(`export format '${format}' is not supported`), 'ERR_INVALID_EXPORT_FORMAT')
     }

--- a/src/keys/rsa-utils.js
+++ b/src/keys/rsa-utils.js
@@ -8,6 +8,7 @@ const { bigIntegerToUintBase64url, base64urlToBigInteger } = require('./../util'
 
 // Convert a PKCS#1 in ASN1 DER format to a JWK key
 exports.pkcs1ToJwk = function (bytes) {
+  bytes = Buffer.from(bytes) // convert Uint8Arrays
   const asn1 = forge.asn1.fromDer(bytes.toString('binary'))
   const privateKey = forge.pki.privateKeyFromAsn1(asn1)
 

--- a/src/keys/secp256k1-class.js
+++ b/src/keys/secp256k1-class.js
@@ -4,7 +4,7 @@ const multibase = require('multibase')
 const sha = require('multihashing-async/src/sha')
 const errcode = require('err-code')
 
-const ciphers = require('../ciphers/aes-gcm')
+const exporter = require('./exporter')
 
 module.exports = (keysProtobuf, randomBytes, crypto) => {
   crypto = crypto || require('./secp256k1')(randomBytes)
@@ -93,12 +93,11 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
      *
      * @param {string} password - The password to encrypt the key
      * @param {string} [format] - Defaults to 'libp2p-key'.
-     * @returns {Promise<Buffer>} The encrypted private key
+     * @returns {Promise<string>} The encrypted private key
      */
     async export (password, format = 'libp2p-key') { // eslint-disable-line require-await
       if (format === 'libp2p-key') {
-        const cipher = ciphers.create()
-        return cipher.encrypt(this.bytes, password)
+        return exporter.export(this.bytes, password)
       } else {
         throw errcode(new Error(`export format '${format}' is not supported`), 'ERR_INVALID_EXPORT_FORMAT')
       }

--- a/src/keys/secp256k1-class.js
+++ b/src/keys/secp256k1-class.js
@@ -2,6 +2,9 @@
 
 const multibase = require('multibase')
 const sha = require('multihashing-async/src/sha')
+const errcode = require('err-code')
+
+const ciphers = require('../ciphers/aes-gcm')
 
 module.exports = (keysProtobuf, randomBytes, crypto) => {
   crypto = crypto || require('./secp256k1')(randomBytes)
@@ -83,6 +86,22 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
     async id () {
       const hash = await this.public.hash()
       return multibase.encode('base58btc', hash).toString().slice(1)
+    }
+
+    /**
+     * Exports the key into a password protected `format`
+     *
+     * @param {string} password - The password to encrypt the key
+     * @param {string} [format] - Defaults to 'libp2p-key'.
+     * @returns {Promise<Buffer>} The encrypted private key
+     */
+    async export (password, format = 'libp2p-key') { // eslint-disable-line require-await
+      if (format === 'libp2p-key') {
+        const cipher = ciphers.create()
+        return cipher.encrypt(this.bytes, password)
+      } else {
+        throw errcode(new Error(`export format '${format}' is not supported`), 'ERR_INVALID_EXPORT_FORMAT')
+      }
     }
   }
 

--- a/src/keys/secp256k1-class.js
+++ b/src/keys/secp256k1-class.js
@@ -92,7 +92,7 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
      * Exports the key into a password protected `format`
      *
      * @param {string} password - The password to encrypt the key
-     * @param {string} [format] - Defaults to 'libp2p-key'.
+     * @param {string} [format=libp2p-key] - The format in which to export as
      * @returns {Promise<string>} The encrypted private key
      */
     async export (password, format = 'libp2p-key') { // eslint-disable-line require-await

--- a/test/browser.js
+++ b/test/browser.js
@@ -2,9 +2,11 @@
 'use strict'
 
 const chai = require('chai')
-const dirtyChai = require('dirty-chai')
+chai.use(require('dirty-chai'))
 const expect = chai.expect
-chai.use(dirtyChai)
+
+const { Buffer } = require('buffer')
+
 const crypto = require('../')
 const webcrypto = require('../src/webcrypto')
 

--- a/test/keys/ed25519.spec.js
+++ b/test/keys/ed25519.spec.js
@@ -88,7 +88,6 @@ describe('ed25519', function () {
   it('should export a password encrypted libp2p-key', async () => {
     const key = await crypto.keys.generateKeyPair('Ed25519')
     const encryptedKey = await key.export('my secret')
-    console.log(encryptedKey)
     // Import the key
     const importedKey = await crypto.keys.import(encryptedKey, 'my secret')
     expect(key.equals(importedKey)).to.equal(true)

--- a/test/keys/ed25519.spec.js
+++ b/test/keys/ed25519.spec.js
@@ -93,6 +93,18 @@ describe('ed25519', function () {
     expect(key.equals(importedKey)).to.equal(true)
   })
 
+  it('should fail to import libp2p-key with wrong password', async () => {
+    const key = await crypto.keys.generateKeyPair('Ed25519')
+    const encryptedKey = await key.export('my secret', 'libp2p-key')
+    try {
+      await crypto.keys.import(encryptedKey, 'not my secret', 'libp2p-key')
+    } catch (err) {
+      expect(err).to.exist()
+      return
+    }
+    expect.fail('should have thrown')
+  })
+
   describe('key equals', () => {
     it('equals itself', () => {
       expect(

--- a/test/keys/ed25519.spec.js
+++ b/test/keys/ed25519.spec.js
@@ -88,8 +88,9 @@ describe('ed25519', function () {
   it('should export a password encrypted libp2p-key', async () => {
     const key = await crypto.keys.generateKeyPair('Ed25519')
     const encryptedKey = await key.export('my secret')
+    console.log(encryptedKey)
     // Import the key
-    const importedKey = await crypto.keys.import(encryptedKey, 'my secret', 'libp2p-key')
+    const importedKey = await crypto.keys.import(encryptedKey, 'my secret')
     expect(key.equals(importedKey)).to.equal(true)
   })
 

--- a/test/keys/ed25519.spec.js
+++ b/test/keys/ed25519.spec.js
@@ -97,7 +97,7 @@ describe('ed25519', function () {
     const key = await crypto.keys.generateKeyPair('Ed25519')
     const encryptedKey = await key.export('my secret', 'libp2p-key')
     try {
-      await crypto.keys.import(encryptedKey, 'not my secret', 'libp2p-key')
+      await crypto.keys.import(encryptedKey, 'not my secret')
     } catch (err) {
       expect(err).to.exist()
       return

--- a/test/keys/ed25519.spec.js
+++ b/test/keys/ed25519.spec.js
@@ -85,6 +85,14 @@ describe('ed25519', function () {
     expect(id).to.be.a('string')
   })
 
+  it('should export a password encrypted libp2p-key', async () => {
+    const key = await crypto.keys.generateKeyPair('Ed25519')
+    const encryptedKey = await key.export('my secret')
+    // Import the key
+    const importedKey = await crypto.keys.import(encryptedKey, 'my secret', 'libp2p-key')
+    expect(key.equals(importedKey)).to.equal(true)
+  })
+
   describe('key equals', () => {
     it('equals itself', () => {
       expect(

--- a/test/keys/rsa.spec.js
+++ b/test/keys/rsa.spec.js
@@ -138,14 +138,14 @@ describe('RSA', function () {
     it('should export a password encrypted libp2p-key', async () => {
       const encryptedKey = await key.export('my secret', 'libp2p-key')
       // Import the key
-      const importedKey = await crypto.keys.import(encryptedKey, 'my secret', 'libp2p-key')
+      const importedKey = await crypto.keys.import(encryptedKey, 'my secret')
       expect(key.equals(importedKey)).to.equal(true)
     })
 
     it('should fail to import libp2p-key with wrong password', async () => {
       const encryptedKey = await key.export('my secret', 'libp2p-key')
       try {
-        await crypto.keys.import(encryptedKey, 'not my secret', 'libp2p-key')
+        await crypto.keys.import(encryptedKey, 'not my secret')
       } catch (err) {
         expect(err).to.exist()
         return

--- a/test/keys/rsa.spec.js
+++ b/test/keys/rsa.spec.js
@@ -135,6 +135,24 @@ describe('RSA', function () {
       expect(key.equals(clone)).to.eql(true)
     })
 
+    it('should export a password encrypted libp2p-key', async () => {
+      const encryptedKey = await key.export('my secret', 'libp2p-key')
+      // Import the key
+      const importedKey = await crypto.keys.import(encryptedKey, 'my secret', 'libp2p-key')
+      expect(key.equals(importedKey)).to.equal(true)
+    })
+
+    it('should fail to import libp2p-key with wrong password', async () => {
+      const encryptedKey = await key.export('my secret', 'libp2p-key')
+      try {
+        await crypto.keys.import(encryptedKey, 'not my secret', 'libp2p-key')
+      } catch (err) {
+        expect(err).to.exist()
+        return
+      }
+      expect.fail('should have thrown')
+    })
+
     it('needs correct password', async () => {
       const pem = await key.export('another secret')
       try {

--- a/test/keys/secp256k1.spec.js
+++ b/test/keys/secp256k1.spec.js
@@ -63,6 +63,26 @@ describe('secp256k1 keys', () => {
     expect(id).to.be.a('string')
   })
 
+  it('should export a password encrypted libp2p-key', async () => {
+    const key = await crypto.keys.generateKeyPair('secp256k1')
+    const encryptedKey = await key.export('my secret')
+    // Import the key
+    const importedKey = await crypto.keys.import(encryptedKey, 'my secret', 'libp2p-key')
+    expect(key.equals(importedKey)).to.equal(true)
+  })
+
+  it('should fail to import libp2p-key with wrong password', async () => {
+    const key = await crypto.keys.generateKeyPair('secp256k1')
+    const encryptedKey = await key.export('my secret', 'libp2p-key')
+    try {
+      await crypto.keys.import(encryptedKey, 'not my secret', 'libp2p-key')
+    } catch (err) {
+      expect(err).to.exist()
+      return
+    }
+    expect.fail('should have thrown')
+  })
+
   describe('key equals', () => {
     it('equals itself', () => {
       expect(key.equals(key)).to.eql(true)

--- a/test/keys/secp256k1.spec.js
+++ b/test/keys/secp256k1.spec.js
@@ -67,7 +67,7 @@ describe('secp256k1 keys', () => {
     const key = await crypto.keys.generateKeyPair('secp256k1')
     const encryptedKey = await key.export('my secret')
     // Import the key
-    const importedKey = await crypto.keys.import(encryptedKey, 'my secret', 'libp2p-key')
+    const importedKey = await crypto.keys.import(encryptedKey, 'my secret')
     expect(key.equals(importedKey)).to.equal(true)
   })
 
@@ -75,7 +75,7 @@ describe('secp256k1 keys', () => {
     const key = await crypto.keys.generateKeyPair('secp256k1')
     const encryptedKey = await key.export('my secret', 'libp2p-key')
     try {
-      await crypto.keys.import(encryptedKey, 'not my secret', 'libp2p-key')
+      await crypto.keys.import(encryptedKey, 'not my secret')
     } catch (err) {
       expect(err).to.exist()
       return


### PR DESCRIPTION
This PR adds support for exporting/importing all keys in the `libp2p-key` format discussed in https://github.com/libp2p/js-libp2p-crypto/issues/145#issuecomment-661251436. This is designed to be a non breaking change. A future breaking change should update the default export of rsa to also be `libp2p-key` and provide an example for how to perform the migration of previously used keys.

Exported keys are encrypted via the AES-GCM algorithm using password derived PBKDF2 keys. They are exported as base64 encoded strings. I originally considered prefixing the exported bytes with a multibase prefix/multicodec prefix to make it easier to determine key type, but this would violate other formats like PEM, so we wouldn't get any meaningful reusability out of this.

This leverages Node.js and Webcrypto support only.

js-libp2p (including interop with go) and js-ipfs test suites are passing using this module. There pertinent PRs are referenced in the history below.
