### PR TITLE
fix: remove rendundant public key

### DIFF
--- a/src/keys/ed25519-class.js
+++ b/src/keys/ed25519-class.js
@@ -5,7 +5,6 @@ const protobuf = require('protons')
 const multibase = require('multibase')
 const errcode = require('err-code')
 const uint8ArrayEquals = require('uint8arrays/equals')
-const uint8ArrayConcat = require('uint8arrays/concat')
 
 const crypto = require('./ed25519')
 const pbm = protobuf(require('./keys.proto'))

--- a/src/keys/ed25519-class.js
+++ b/src/keys/ed25519-class.js
@@ -57,7 +57,7 @@ class Ed25519PrivateKey {
   }
 
   marshal () {
-    return uint8ArrayConcat([this._key, this._publicKey])
+    return this._key
   }
 
   get bytes () {

--- a/test/keys/ed25519.spec.js
+++ b/test/keys/ed25519.spec.js
@@ -157,6 +157,13 @@ describe('ed25519', function () {
       expect(ok).to.eql(true)
     })
 
+    it('does not include the redundant public key when marshalling privatekey', async () => {
+      const key = await crypto.keys.unmarshalPrivateKey(fixtures.redundantPubKey.privateKey)
+      const bytes = key.marshal()
+      expect(bytes.length).to.equal(64)
+      expect(bytes.slice(32)).to.eql(key.public.marshal())
+    })
+
     it('verifies with data from go with redundant public key', async () => {
       const key = crypto.keys.unmarshalPublicKey(fixtures.redundantPubKey.publicKey)
       const ok = await key.verify(fixtures.redundantPubKey.data, fixtures.redundantPubKey.signature)


### PR DESCRIPTION
BREAKING CHANGE: The private ed25519 key will no longer include the redundant public key


This is the breaking change portion of https://github.com/libp2p/js-libp2p-crypto/pull/178, which completes the coversion.