### PR TITLE
chore: remove unused type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 /**
  * Supported key types.
  */


### PR DESCRIPTION
tested locally, I couldn't find any use of the node types here.

With this node type, there is a required peer dependency of `@types/node`