### PR TITLE
Fix Ed25519 PeerID generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "keypair": "^1.0.1",
     "multibase": "^3.0.0",
     "multicodec": "^2.0.0",
+    "multihashes": "^4.0.2",
     "multihashing-async": "^2.0.1",
     "node-forge": "^0.10.0",
     "pem-jwk": "^2.0.0",

--- a/src/keys/ed25519-class.js
+++ b/src/keys/ed25519-class.js
@@ -4,8 +4,7 @@ const sha = require('multihashing-async/src/sha')
 const protobuf = require('protons')
 const errcode = require('err-code')
 const uint8ArrayEquals = require('uint8arrays/equals')
-const uint8ArrayToString = require('uint8arrays/to-string')
-
+const mh = require('multihashes')
 const crypto = require('./ed25519')
 const pbm = protobuf(require('./keys.proto'))
 const exporter = require('./exporter')
@@ -84,8 +83,8 @@ class Ed25519PrivateKey {
    * @returns {Promise<String>}
    */
   async id () {
-    const hash = await this.public.hash()
-    return uint8ArrayToString(hash, 'base58btc')
+    const encoding = mh.encode(this.public.bytes, 'identity')
+    return await mh.toB58String(encoding)
   }
 
   /**

--- a/test/keys/ed25519.spec.js
+++ b/test/keys/ed25519.spec.js
@@ -82,7 +82,7 @@ describe('ed25519', function () {
   it('key id', async () => {
     const key = await crypto.keys.unmarshalPrivateKey(fixtures.verify.privateKey)
     const id = await key.id()
-    expect(id).to.eql('QmUawW9qzMrBBiMrWQQMvoatadKZ9F4EwZCAMKnt3STLtz')
+    expect(id).to.eql('12D3KooWLqLxEfJ9nDdEe8Kh8PFvNPQRYDQBwyL7CMM7HhVd5LsX')
   })
 
   it('should export a password encrypted libp2p-key', async () => {


### PR DESCRIPTION
This commit pushes further fixes to the generation of Ed25519 peer IDs,
building upon the discussion in ipfs/js-ipfs#3591 and the subsequent
pull request libp2p/js-libp2p-crypto#185.

The purpose of this new pull request is to harmonize the encoding of
PeerIDs for Ed25519 keys such that the same new format is used
everywhere: peer IDs when assigned upon key generation, peer IDs when
shown via key listing, as well as the peer IDs displayed as IPNS names
when the key is used as the basis for an IPNS record.

Concretely, this changes the peer ID representation of Ed25519 keys from
the `Qm...` format to the newer `1...` format.

The accompanying test has been modified accordingly.