### PR TITLE
chore: upgrades to new multiformats module

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,7 @@
     "is-typedarray": "^1.0.0",
     "iso-random-stream": "^2.0.0",
     "keypair": "^1.0.1",
-    "multibase": "^4.0.3",
-    "multicodec": "^3.0.1",
-    "multihashes": "^4.0.2",
-    "multihashing-async": "^2.1.2",
+    "multiformats": "^9.1.2",
     "node-forge": "^0.10.0",
     "pem-jwk": "^2.0.0",
     "protobufjs": "^6.10.2",
@@ -55,21 +52,15 @@
     "ursa-optional": "^0.10.1"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.12",
-    "@types/chai-string": "^1.4.2",
-    "@types/dirty-chai": "^2.0.2",
     "@types/mocha": "^8.0.1",
     "aegir": "^33.0.0",
     "benchmark": "^2.1.4",
-    "chai": "^4.2.0",
-    "chai-string": "^1.5.0",
-    "dirty-chai": "^2.0.1",
-    "sinon": "^10.0.0",
+    "sinon": "^11.1.1",
     "util": "^0.12.3"
   },
   "aegir": {
     "build": {
-      "bundlesizeMax": "118kB"
+      "bundlesizeMax": "116kB"
     }
   },
   "engines": {

--- a/src/keys/rsa-class.js
+++ b/src/keys/rsa-class.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const sha = require('multihashing-async/src/sha')
+const { sha256 } = require('multiformats/hashes/sha2')
 const errcode = require('err-code')
 const uint8ArrayEquals = require('uint8arrays/equals')
 const uint8ArrayToString = require('uint8arrays/to-string')
@@ -41,8 +41,10 @@ class RsaPublicKey {
     return uint8ArrayEquals(this.bytes, key.bytes)
   }
 
-  async hash () { // eslint-disable-line require-await
-    return sha.multihashing(this.bytes, 'sha2-256')
+  async hash () {
+    const { bytes } = await sha256.digest(this.bytes)
+
+    return bytes
   }
 }
 
@@ -89,8 +91,10 @@ class RsaPrivateKey {
     return uint8ArrayEquals(this.bytes, key.bytes)
   }
 
-  async hash () { // eslint-disable-line require-await
-    return sha.multihashing(this.bytes, 'sha2-256')
+  async hash () {
+    const { bytes } = await sha256.digest(this.bytes)
+
+    return bytes
   }
 
   /**

--- a/src/keys/secp256k1-class.js
+++ b/src/keys/secp256k1-class.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const sha = require('multihashing-async/src/sha')
+const { sha256 } = require('multiformats/hashes/sha2')
 const errcode = require('err-code')
 const uint8ArrayEquals = require('uint8arrays/equals')
 const uint8ArrayToString = require('uint8arrays/to-string')
@@ -35,8 +35,10 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
       return uint8ArrayEquals(this.bytes, key.bytes)
     }
 
-    hash () {
-      return sha.multihashing(this.bytes, 'sha2-256')
+    async hash () {
+      const { bytes } = await sha256.digest(this.bytes)
+
+      return bytes
     }
   }
 
@@ -71,8 +73,10 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
       return uint8ArrayEquals(this.bytes, key.bytes)
     }
 
-    hash () {
-      return sha.multihashing(this.bytes, 'sha2-256')
+    async hash () {
+      const { bytes } = await sha256.digest(this.bytes)
+
+      return bytes
     }
 
     /**

--- a/src/keys/secp256k1.js
+++ b/src/keys/secp256k1.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const secp256k1 = require('secp256k1')
-const sha = require('multihashing-async/src/sha')
-const HASH_ALGORITHM = 'sha2-256'
+const { sha256 } = require('multiformats/hashes/sha2')
 
 module.exports = (randomBytes) => {
   const privateKeyLength = 32
@@ -16,13 +15,13 @@ module.exports = (randomBytes) => {
   }
 
   async function hashAndSign (key, msg) {
-    const digest = await sha.digest(msg, HASH_ALGORITHM)
+    const { digest } = await sha256.digest(msg)
     const sig = secp256k1.ecdsaSign(digest, key)
     return secp256k1.signatureExport(sig.signature)
   }
 
   async function hashAndVerify (key, sig, msg) {
-    const digest = await sha.digest(msg, HASH_ALGORITHM)
+    const { digest } = await sha256.digest(msg)
     sig = secp256k1.signatureImport(sig)
     return secp256k1.ecdsaVerify(sig, digest, key)
   }

--- a/test/aes/aes.spec.js
+++ b/test/aes/aes.spec.js
@@ -3,10 +3,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const { expectErrCode } = require('../util')
 
 const crypto = require('../../src')

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const crypto = require('../')

--- a/test/crypto.spec.js
+++ b/test/crypto.spec.js
@@ -2,10 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const crypto = require('../src')
 const fixtures = require('./fixtures/go-key-rsa')
 const { expectErrCode } = require('./util')

--- a/test/hmac/hmac.spec.js
+++ b/test/hmac/hmac.spec.js
@@ -2,10 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const crypto = require('../../src')

--- a/test/keys/ed25519.spec.js
+++ b/test/keys/ed25519.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const crypto = require('../../src')

--- a/test/keys/ephemeral-keys.spec.js
+++ b/test/keys/ephemeral-keys.spec.js
@@ -2,10 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 
 const fixtures = require('../fixtures/go-elliptic-key')
 const crypto = require('../../src')

--- a/test/keys/key-stretcher.spec.js
+++ b/test/keys/key-stretcher.spec.js
@@ -2,10 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const { expectErrCode } = require('../util')
 const crypto = require('../../src')
 const fixtures = require('../fixtures/go-stretch-key')

--- a/test/keys/rsa-crypto-libs.js
+++ b/test/keys/rsa-crypto-libs.js
@@ -3,11 +3,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 8] */
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-chai.use(require('chai-string'))
+const { expect } = require('aegir/utils/chai')
 
 const LIBS = ['ursa', 'keypair']
 

--- a/test/keys/rsa.spec.js
+++ b/test/keys/rsa.spec.js
@@ -2,11 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-chai.use(require('chai-string'))
+const { expect } = require('aegir/utils/chai')
 const { expectErrCode } = require('../util')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 

--- a/test/keys/secp256k1.spec.js
+++ b/test/keys/secp256k1.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const crypto = require('../../src')
 const secp256k1 = crypto.keys.supportedKeys.secp256k1
 const keysPBM = crypto.keys.keysPBM

--- a/test/random-bytes.spec.js
+++ b/test/random-bytes.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 
 const randomBytes = require('../src/random-bytes')
 

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -2,10 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 require('node-forge/lib/jsbn')
 const forge = require('node-forge/lib/forge')
 const util = require('../src/util')

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -1,8 +1,7 @@
 /* eslint-disable valid-jsdoc */
 'use strict'
 
-const chai = require('chai')
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 
 // @ts-check
 /**


### PR DESCRIPTION
Removes multibase/multicodec/multihashing in favour of the implementations in the new multiformats module.

Turns out all we really use is sha2-256 and identity, we don't need all the other stuff it pulls in.