### PR TITLE
fix: back port node forge bump to 0.16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "keypair": "^1.0.1",
     "libp2p-crypto-secp256k1": "~0.3.0",
     "multihashing-async": "~0.5.1",
-    "node-forge": "~0.9.1",
+    "node-forge": "^0.10.0",
     "pem-jwk": "^2.0.0",
     "protons": "^1.0.1",
     "rsa-pem-to-jwk": "^1.1.3",


### PR DESCRIPTION
This bumps the version of node-forge to remove a security issue. There's still quite a bit of downloads for the 0.16.x version. The minor version of node-forge only included a breaking change in the supported node version (dropped Node 4), which 0.16.x already does not support, so only a patch is required here.