### PR TITLE
fix: relax .equals type

### DIFF
--- a/src/keys/ed25519-class.ts
+++ b/src/keys/ed25519-class.ts
@@ -29,7 +29,7 @@ export class Ed25519PublicKey {
     }).finish()
   }
 
-  equals (key: Ed25519PublicKey) {
+  equals (key: any) {
     return uint8ArrayEquals(this.bytes, key.bytes)
   }
 
@@ -70,7 +70,7 @@ export class Ed25519PrivateKey {
     }).finish()
   }
 
-  equals (key: Ed25519PrivateKey) {
+  equals (key: any) {
     return uint8ArrayEquals(this.bytes, key.bytes)
   }
 

--- a/src/keys/rsa-class.ts
+++ b/src/keys/rsa-class.ts
@@ -36,7 +36,7 @@ export class RsaPublicKey {
     return crypto.encrypt(this._key, bytes)
   }
 
-  equals (key: RsaPublicKey) {
+  equals (key: any) {
     return uint8ArrayEquals(this.bytes, key.bytes)
   }
 
@@ -87,7 +87,7 @@ export class RsaPrivateKey {
     }).finish()
   }
 
-  equals (key: RsaPrivateKey) {
+  equals (key: any) {
     return uint8ArrayEquals(this.bytes, key.bytes)
   }
 

--- a/src/keys/secp256k1-class.ts
+++ b/src/keys/secp256k1-class.ts
@@ -29,7 +29,7 @@ export class Secp256k1PublicKey {
     }).finish()
   }
 
-  equals (key: Secp256k1PublicKey) {
+  equals (key: any) {
     return uint8ArrayEquals(this.bytes, key.bytes)
   }
 
@@ -70,7 +70,7 @@ export class Secp256k1PrivateKey {
     }).finish()
   }
 
-  equals (key: Secp256k1PrivateKey) {
+  equals (key: any) {
     return uint8ArrayEquals(this.bytes, key.bytes)
   }
 


### PR DESCRIPTION
Accept `any` otherwise we aren't compatible with the types in libp2p-intefaces.