### PR TITLE
chore: change min node support to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "wherearewe": "^1.0.0"
   },
   "engines": {
-    "node": ">=15.0.0"
+    "node": ">=16.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This library does not work with node 15 (#221).
Moreover, node 15 has reached End-of-Life.

Resolves #221.