### PR TITLE
fix: pin @noble/ed25519 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@noble/ed25519": "^1.3.0",
+    "@noble/ed25519": "1.4.x",
     "@noble/secp256k1": "^1.3.0",
     "err-code": "^3.0.1",
     "iso-random-stream": "^2.0.0",


### PR DESCRIPTION
`@noble/ed25519@1.5.0` introduces a regression around signatures so
pin to `1.4.0` while it is resolved.

Refs: https://github.com/paulmillr/noble-ed25519/issues/45