### PR TITLE
fix: bump noble-ed25519 to an audited version

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "build:proto:types": "pbts -o src/keys/keys.d.ts src/keys/keys.js"
   },
   "dependencies": {
-    "@noble/ed25519": "^1.3.3",
+    "@noble/ed25519": "^1.6.0",
     "@noble/secp256k1": "^1.3.4",
     "err-code": "^3.0.1",
     "iso-random-stream": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
   },
   "dependencies": {
     "@noble/ed25519": "^1.6.0",
-    "@noble/secp256k1": "^1.3.4",
+    "@noble/secp256k1": "^1.5.4",
     "err-code": "^3.0.1",
     "iso-random-stream": "^2.0.0",
     "multiformats": "^9.4.5",


### PR DESCRIPTION
This makes sure it's always 1.6.0+ and not just 1.4.0 if some dep is also using 1.4.0

https://github.com/paulmillr/noble-ed25519/releases/tag/1.6.0