### PR TITLE
fix: remove iso-random-stream dependency

### DIFF
--- a/benchmark/ed25519/compat.cjs
+++ b/benchmark/ed25519/compat.cjs
@@ -16,12 +16,12 @@ const forge = require('node-forge/lib/forge')
  * function because key generation is deterministic for a given seed.
  */
 
-const randomBytes = require('iso-random-stream/src/random')
 const { concat } = require('uint8arrays/concat')
 const { fromString } = require('uint8arrays/from-string')
 
 const native = require('ed25519')
 const noble = require('@noble/ed25519')
+const { randomBytes } = noble.utils
 const { subtle } = require('crypto').webcrypto
 require('node-forge/lib/ed25519')
 const stable = require('@stablelib/ed25519')

--- a/benchmark/ed25519/index.cjs
+++ b/benchmark/ed25519/index.cjs
@@ -2,9 +2,9 @@
 // @ts-expect-error types are missing
 const forge = require('node-forge/lib/forge')
 const Benchmark = require('benchmark')
-const randomBytes = require('iso-random-stream/src/random')
 const native = require('ed25519')
 const noble = require('@noble/ed25519')
+const { randomBytes } = noble.utils
 const { subtle } = require('crypto').webcrypto
 require('node-forge/lib/ed25519')
 const stable = require('@stablelib/ed25519')

--- a/benchmark/ed25519/package.json
+++ b/benchmark/ed25519/package.json
@@ -13,7 +13,6 @@
     "benchmark": "^2.1.4",
     "ed25519": "^0.0.5",
     "ed25519-wasm-pro": "^1.1.1",
-    "iso-random-stream": "^2.0.0",
     "node-forge": "^1.0.0",
     "supercop.wasm": "^5.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
     "@noble/ed25519": "^1.6.0",
     "@noble/secp256k1": "^1.5.4",
     "err-code": "^3.0.1",
-    "iso-random-stream": "^2.0.0",
     "multiformats": "^9.4.5",
     "node-forge": "^1.1.0",
     "protons-runtime": "^1.0.4",

--- a/src/random-bytes.ts
+++ b/src/random-bytes.ts
@@ -1,9 +1,9 @@
-import isoRandomBytes from 'iso-random-stream/src/random.js'
+import { utils } from '@noble/secp256k1'
 import errcode from 'err-code'
 
 export default function randomBytes (length: number): Uint8Array {
   if (isNaN(length) || length <= 0) {
     throw errcode(new Error('random bytes length must be a Number bigger than 0'), 'ERR_INVALID_LENGTH')
   }
-  return isoRandomBytes(length)
+  return utils.randomBytes(length)
 }


### PR DESCRIPTION
This dependency brings in NodeJS's `Buffer` which then needs to be polyfilled in the browser.

`@noble/*` already brings a utility that switch between Node's and the browser's `randomBytes` interfaces.

One caveat is that `iso-random-stream` enables generation of arrays greater than 65536 in length in the browser.
It does not strike to me as a feature needed for libp2p-crypto. Let me know your thoughts.