### PR TITLE
fix: deriveKey in webkit linux (workaround)

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "test:chrome-webworker": "aegir test -t webworker",
     "test:firefox": "aegir test -t browser -- --browser firefox",
     "test:firefox-webworker": "aegir test -t webworker -- --browser firefox",
+    "test:webkit": "aegir test -t browser -- --browser webkit",
     "test:node": "aegir test -t node --cov",
     "test:electron-main": "aegir test -t electron-main",
     "release": "aegir release",


### PR DESCRIPTION
After some painful debugging (see: https://github.com/libp2p/js-libp2p/pull/1627#issuecomment-1483401928) I've found out why js-libp2p fails on webkit in Linux. The subtlecrypto implementation doesn't like to derive a key from an empty imported key. This works on all other browsers, so it seems like the webkit implementation is doing the wrong thing. Maybe worth opening a bug and writing a test for them. In the mean time here's a workaround.

This unblocks webkit testing in the interop tester (which runs on linux). This also lets folks use js-libp2p from webkit based linux browsers, although it doesn't seem like anyone else ran into this issue.

